### PR TITLE
feat: Dockerize

### DIFF
--- a/.db.env.example
+++ b/.db.env.example
@@ -1,0 +1,3 @@
+POSTGRES_USER=<your-user>
+POSTGRES_PASSWORD=<your-password>
+POSTGRES_DB=swampstudy

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Database environmental variables
+.db.env

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: Build the app with Vite
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve static files with Nginx
+FROM nginx:stable-alpine
+# Remove default Nginx static assets
+RUN rm -rf /usr/share/nginx/html/*
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        # First try to serve the URI as a file, then as a directory,
+        # and if that fails, serve index.html.
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 404 /index.html;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+// This is for dev only now. Traefik is used in production.
 export default defineConfig({
   plugins: [react()],
   server: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:13
+    restart: always
+    env_file:
+      - .db.env
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - app-network
+
+  server:
+    build: ./server
+    depends_on:
+      - postgres
+    env_file:
+      - ./server/.env
+    ports:
+      - "3000:3000"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - app-network
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.api.rule=Host(`swampstudy.com`) && PathPrefix(`/api`)"
       - "traefik.http.routers.api.entrypoints=web,websecure"
       - "traefik.http.routers.api.priority=10"
       - "traefik.http.routers.api.tls=true"
@@ -68,12 +68,14 @@ services:
       # HTTP router: listens on port 80 and redirects to HTTPS
       - "traefik.http.routers.client-http.rule=Host(`swampstudy.com`) || Host(`www.swampstudy.com`)"
       - "traefik.http.routers.client-http.entrypoints=web"
+      - "traefik.http.routers.client-http.priority=1"
       - "traefik.http.routers.client-http.middlewares=redirect-to-https"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
       # HTTPS router: serves the client content over TLS
       - "traefik.http.routers.client.rule=Host(`swampstudy.com`) || Host(`www.swampstudy.com`)"
       - "traefik.http.routers.client.entrypoints=websecure"
+      - "traefik.http.routers.client.priority=1"
       - "traefik.http.routers.client.tls=true"
       - "traefik.http.routers.client.tls.certresolver=myresolver"
       - "traefik.http.services.client.loadbalancer.server.port=80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
     networks:
       - app-network
 
+  client:
+    build: ./client
+    depends_on:
+      - server
+    ports:
+      - "80:80"
+    networks:
+      - app-network
+
 networks:
   app-network:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  traefik:
+    image: traefik:v2.9
+    user: "0"  # root
+    privileged: true
+    command:
+      - --providers.docker=true
+      # Only containers with traefik.enable=true will be exposed.
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      # So Traefik can read Docker labels
+      - /var/run/docker.sock:/var/run/docker.sock:ro,Z
+    networks:
+      - app-network
+
   postgres:
     image: postgres:13
     restart: always
@@ -7,9 +24,11 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5432:5432"  # for dev
     networks:
       - app-network
+    labels:
+      - "traefik.enable=false"
 
   server:
     build: ./server
@@ -18,18 +37,26 @@ services:
     env_file:
       - ./server/.env
     ports:
-      - "3000:3000"
+      - "3000:3000"  # for dev
     networks:
       - app-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.api.priority=10"
+      - "traefik.http.services.api.loadbalancer.server.port=3000"
 
   client:
     build: ./client
     depends_on:
       - server
-    ports:
-      - "80:80"
     networks:
       - app-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.client.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.client.priority=1"
+      - "traefik.http.services.client.loadbalancer.server.port=80"
 
 networks:
   app-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,13 @@ services:
     privileged: true
     command:
       - --providers.docker=true
-      # Only containers with traefik.enable=true will be exposed.
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80  # HTTP
       - --entrypoints.websecure.address=:443  # HTTPS
       - --certificatesresolvers.myresolver.acme.email=ckress@ufl.edu
       - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
       - --certificatesresolvers.myresolver.acme.tlschallenge=true
+
     ports:
       - "80:80"
       - "443:443"
@@ -50,7 +50,6 @@ services:
       - app-network
     labels:
       - "traefik.enable=true"
-      # Define a router for API requests on the secure entrypoint
       - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
       - "traefik.http.routers.api.entrypoints=web,websecure"
       - "traefik.http.routers.api.priority=10"
@@ -66,9 +65,15 @@ services:
       - app-network
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.client.rule=Host(`yourdomain.com`)"
-      - "traefik.http.routers.client.entrypoints=web,websecure"
-      - "traefik.http.routers.client.priority=1"
+      # HTTP router: listens on port 80 and redirects to HTTPS
+      - "traefik.http.routers.client-http.rule=Host(`swampstudy.com`) || Host(`www.swampstudy.com`)"
+      - "traefik.http.routers.client-http.entrypoints=web"
+      - "traefik.http.routers.client-http.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+
+      # HTTPS router: serves the client content over TLS
+      - "traefik.http.routers.client.rule=Host(`swampstudy.com`) || Host(`www.swampstudy.com`)"
+      - "traefik.http.routers.client.entrypoints=websecure"
       - "traefik.http.routers.client.tls=true"
       - "traefik.http.routers.client.tls.certresolver=myresolver"
       - "traefik.http.services.client.loadbalancer.server.port=80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,18 @@ services:
       - --providers.docker=true
       # Only containers with traefik.enable=true will be exposed.
       - --providers.docker.exposedbydefault=false
-      - --entrypoints.web.address=:80
+      - --entrypoints.web.address=:80  # HTTP
+      - --entrypoints.websecure.address=:443  # HTTPS
+      - --certificatesresolvers.myresolver.acme.email=ckress@ufl.edu
+      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.myresolver.acme.tlschallenge=true
     ports:
       - "80:80"
+      - "443:443"
     volumes:
-      # So Traefik can read Docker labels
+      # So Traefik can read Docker labels and manage certificates
       - /var/run/docker.sock:/var/run/docker.sock:ro,Z
+      - traefik-certificates:/letsencrypt
     networks:
       - app-network
 
@@ -36,14 +42,20 @@ services:
       - postgres
     env_file:
       - ./server/.env
+    environment:
+      - NODE_ENV=production
     ports:
       - "3000:3000"  # for dev
     networks:
       - app-network
     labels:
       - "traefik.enable=true"
+      # Define a router for API requests on the secure entrypoint
       - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.api.entrypoints=web,websecure"
       - "traefik.http.routers.api.priority=10"
+      - "traefik.http.routers.api.tls=true"
+      - "traefik.http.routers.api.tls.certresolver=myresolver"
       - "traefik.http.services.api.loadbalancer.server.port=3000"
 
   client:
@@ -54,8 +66,11 @@ services:
       - app-network
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.client.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.client.rule=Host(`yourdomain.com`)"
+      - "traefik.http.routers.client.entrypoints=web,websecure"
       - "traefik.http.routers.client.priority=1"
+      - "traefik.http.routers.client.tls=true"
+      - "traefik.http.routers.client.tls.certresolver=myresolver"
       - "traefik.http.services.client.loadbalancer.server.port=80"
 
 networks:
@@ -63,3 +78,4 @@ networks:
 
 volumes:
   pgdata:
+  traefik-certificates:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,5 @@
 DB_USER=<your-user>
 DB_PASSWORD=<your-password>
 DB_NAME=swampstudy
-DB_HOST=localhost
+DB_HOST=localhost # use "postgres" for docker builds
 DB_PORT=5432

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: Build the application
+FROM node:18-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Create a production image
+FROM node:18-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --only=production
+COPY --from=builder /app/build ./build
+EXPOSE 3000
+CMD ["node", "build/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -87,3 +87,14 @@ DB_PORT=5432 # default Postgres port
 **Note:** This file contains secrets and should NEVER be shared. Ensure that it
 is in the `.gitignore` file before pushing to any public repositories (like
 GitHub).
+
+## PostgreSQL Docker Setup
+
+To initialize the database schema in docker, run the following commands to copy
+the schema into the docker container and run it:
+
+```bash
+$ docker cp ./server/src/db/schema.sql <postgres-container-name>:/tmp/schema.sql
+$ docker exec -it <postgres-container-name> \
+    psql -U <your-user> -d swampstudy -f /tmp/schema.sql
+```

--- a/server/README.md
+++ b/server/README.md
@@ -94,7 +94,7 @@ To initialize the database schema in docker, run the following commands to copy
 the schema into the docker container and run it:
 
 ```bash
-$ docker cp ./server/src/db/schema.sql <postgres-container-name>:/tmp/schema.sql
-$ docker exec -it <postgres-container-name> \
+# docker cp ./server/src/db/schema.sql <postgres-container-name>:/tmp/schema.sql
+# docker exec -it <postgres-container-name> \
     psql -U <your-user> -d swampstudy -f /tmp/schema.sql
 ```

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,7 +27,7 @@ server.get("/api/ping", async (_request, _reply) => {
   return "pong";
 });
 
-server.listen({ port: 3000 }, (err, address) => {
+server.listen({ port: 3000, host: "0.0.0.0" }, (err, address) => {
   if (err) {
     console.error(err);
     process.exit(1);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,3 +34,15 @@ server.listen({ port: 3000 }, (err, address) => {
   }
   console.log(`Server listening at ${address}`);
 });
+
+process.on("SIGTERM", async () => {
+  console.log("SIGTERM signal received: closing Fastify");
+  try {
+    await server.close();
+    console.log("Fastify closed");
+    process.exit(0);
+  } catch (err) {
+    console.error("Error during shutdown:", err);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
This PR involves the creation of Docker containers for the server and client, as well as a Docker compose file to orchestrate everything. The server Dockerfile is the simplest: it simply builds the app with `npm run build` and then uses `node` as the runner. The client is also build with an `npm` script, but then uses `nginx` to serve the static files. An `nginx` config is included so that all routes resolve to the root (as this is an SPA and routing is handled by React Router in Javascript).

The docker compose uses these two Docker images as well as a standard PostgreSQL image and Traefik. Traefik is used for both edge routing (replacing Vite during dev) as well as for generating and managing Let's Ecrypt SSL certificates. This is all handled automatically by Traefik.

Everything has been tested and deployed on AWS at https://swampstudy.com.