### PR TITLE
bugfix: Changed Vite proxy to 127.0.0.1 instead of localhost

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: "http://127.0.0.1:3000",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
This fixes a small bug where some systems don't recognize' localhost'. It just uses `127.0.0.1` directly instead.