### PR TITLE
bugfix: Added `tests/` directory to tsconfig

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -26,7 +26,10 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "src",                                  /* Specify the root folder within your source files. */
+    "rootDirs": [
+      "./src",
+      "./tests"
+    ],                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -107,5 +110,9 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ]
 }


### PR DESCRIPTION
This PR adds the `tests/` route to the `server/tsconfig.json` to fix some errors. This shouldn't affect any functionality besides preventing those errors when for `npm run test`.