### PR TITLE
bugfix: Show/hide password toggle button

### DIFF
--- a/client/src/components/FormInput.tsx
+++ b/client/src/components/FormInput.tsx
@@ -79,7 +79,7 @@ export default function FormInput({
         <button
           type="button"
           onClick={onPasswordToggle}
-          className="absolute right-3 top-1/2 -translate-y-1/2
+          className="absolute right-2 top-1/6 -translate-y-1/2
                      p-1.5 rounded-md
                      hover:bg-gray-100 dark:hover:bg-gray-700
                      focus:outline-none focus:ring-2 focus:ring-blue-500

--- a/client/src/components/FormInput.tsx
+++ b/client/src/components/FormInput.tsx
@@ -74,12 +74,12 @@ export default function FormInput({
 
   if (passwordToggle) {
     return (
-      <div className="relative">
+      <div className="relative flex items-center">
         {input}
         <button
           type="button"
           onClick={onPasswordToggle}
-          className="absolute right-2 top-1/6 -translate-y-1/2
+          className="absolute right-3 flex items-center justify-center
                      p-1.5 rounded-md
                      hover:bg-gray-100 dark:hover:bg-gray-700
                      focus:outline-none focus:ring-2 focus:ring-blue-500


### PR DESCRIPTION
Fixed the formatting for the <img> tag in FormatInput for the password toggle, it was misaligned on my local so I just changed the styling to fix it and make it look cohesive. Run the frontend and make sure its aligned properly just to be safe I wasnt having some weird render error on my end only and that it looks normal (go to swampstudy.com to see what it was like before).