### PR TITLE
feat: Group search page and state management

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,8 @@
         "react-dom": "^19.0.0",
         "react-router": "^7.3.0",
         "tailwindcss": "^4.1.4",
-        "zod": "^3.24.3"
+        "zod": "^3.24.3",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1613,7 +1614,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2105,7 +2106,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3766,6 +3767,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@tailwindcss/vite": "^4.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -875,6 +876,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@tailwindcss/vite": "^4.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^19.0.0",
     "react-router": "^7.3.0",
     "tailwindcss": "^4.1.4",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/client/src/components/LogoutButton.tsx
+++ b/client/src/components/LogoutButton.tsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuthFetch } from "../hooks/useAuthFetch";
+import { useUserStore } from "../stores/userStore";
 
 export default function LogoutButton() {
   const authFetch = useAuthFetch();
   const navigate = useNavigate();
+  const { user, setUser } = useUserStore(state => state);
   const [logoutAll, setLogoutAll] = useState(false);
 
   async function handleLogout() {
+    if (!user) {
+      navigate("/login");
+      return;
+    }
     const endpoint = logoutAll ? "/api/auth/logout-all"
                                : "/api/auth/logout";
     try {
@@ -20,7 +26,7 @@ export default function LogoutButton() {
 
       const data = await response.json();
       console.log("Logout successful:", data.message);
-      // TODO: Update user state
+      setUser(null);
       navigate("/login");
     } catch (error) {
       console.error("Error during logout:", error);

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { useUserStore } from "../stores/userStore";
+import { UserSchema } from "../types";
+import { useAuthFetch } from "./useAuthFetch";
+
+export function useAuth() {
+  const user = useUserStore((state) => state.user);
+  const setUser = useUserStore((state) => state.setUser);
+  const navigate = useNavigate();
+  const authFetch = useAuthFetch();
+  const [loading, setLoading] = useState(!user);
+
+  useEffect(() => {
+    if (user) {
+      setLoading(false);
+      return;
+    }
+
+    async function verifySession() {
+      try {
+        const response = await authFetch("/api/auth/verify", { method: "GET" });
+        if (!response.ok) {
+          setUser(null);
+          navigate("/login");
+          return;
+        }
+        const data = await response.json();
+        const user = UserSchema.parse(data.user);
+        setUser(user);
+      } catch (err) {
+        setUser(null);
+        navigate("/login");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    verifySession();
+  }, [user, setUser, navigate]);
+
+  return { user, loading };
+}

--- a/client/src/hooks/useAuthFetch.ts
+++ b/client/src/hooks/useAuthFetch.ts
@@ -8,7 +8,6 @@ export function useAuthFetch() {
     async function (
       input: RequestInfo,
       init?: RequestInit,
-      redirectOnFail: boolean = true
     ): Promise<Response> {
       let response = await fetch(input, {
         ...init,
@@ -23,9 +22,6 @@ export function useAuthFetch() {
         });
 
         if (!refreshResponse.ok) {
-          if (redirectOnFail && location.pathname !== "/login") {
-            navigate("/login");
-          }
           const data = await refreshResponse.json();
           throw new Error(
             `Unable to refresh token: ${data?.error || "Unknown error"}`

--- a/client/src/hooks/useFetchGroups.ts
+++ b/client/src/hooks/useFetchGroups.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect } from "react";
+import { Group, GroupSchema } from "../types";
+import { useAuthFetch } from "./useAuthFetch";
+
+export async function fetchGroups(
+  authFetch: ReturnType<typeof useAuthFetch>,
+): Promise<Group[] | null> {
+  try {
+    const response = await authFetch("/api/group", {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      let err = (await response.json())?.error;
+      if (typeof err !== "string") {
+        console.error(err);
+        err = null;
+      }
+      throw new Error(err ?? "Unknown error");
+    }
+
+    const data = await response.json();
+    return GroupSchema.array().parse(data);
+  } catch (err) {
+    console.error("Error fetching groups:", err);
+    return null;
+  }
+}
+
+interface UseFetchGroupsResult {
+  groups: Group[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useFetchGroups(): UseFetchGroupsResult {
+  const authFetch = useAuthFetch();
+
+  const [groups, setGroups] = useState<Group[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const fetchedGroups = await fetchGroups(authFetch);
+        if (fetchGroups !== null) {
+          setGroups(fetchedGroups);
+        } else {
+          setError('Failed to load groups.');
+          setGroups(null);
+        }
+      } catch (err) {
+        console.error('Unexpected error fetching groups:', err);
+        setError('An unexpected error occurred.');
+        setGroups(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+
+  }, [authFetch]);
+
+  return { groups, loading, error };
+}

--- a/client/src/hooks/useFetchGroups.ts
+++ b/client/src/hooks/useFetchGroups.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react";
-import { Group, GroupSchema } from "../types";
+import { GroupWithMemberCount, GroupWithMemberCountSchema } from "../types";
 import { useAuthFetch } from "./useAuthFetch";
 
 export async function fetchGroups(
   authFetch: ReturnType<typeof useAuthFetch>,
-): Promise<Group[] | null> {
+): Promise<GroupWithMemberCount[] | null> {
   try {
     const response = await authFetch("/api/group", {
       method: "GET",
@@ -20,7 +20,7 @@ export async function fetchGroups(
     }
 
     const data = await response.json();
-    return GroupSchema.array().parse(data);
+    return GroupWithMemberCountSchema.array().parse(data);
   } catch (err) {
     console.error("Error fetching groups:", err);
     return null;
@@ -28,7 +28,7 @@ export async function fetchGroups(
 }
 
 interface UseFetchGroupsResult {
-  groups: Group[] | null;
+  groups: GroupWithMemberCount[] | null;
   loading: boolean;
   error: string | null;
 }
@@ -36,7 +36,7 @@ interface UseFetchGroupsResult {
 export function useFetchGroups(): UseFetchGroupsResult {
   const authFetch = useAuthFetch();
 
-  const [groups, setGroups] = useState<Group[] | null>(null);
+  const [groups, setGroups] = useState<GroupWithMemberCount[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/client/src/hooks/useOptionalUser.ts
+++ b/client/src/hooks/useOptionalUser.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { useUserStore } from "../stores/userStore";
+import { UserSchema } from "../types";
+import { useAuthFetch } from "./useAuthFetch";
+
+export function useOptionalUser() {
+  const user = useUserStore((state) => state.user);
+  const setUser = useUserStore((state) => state.setUser);
+  const authFetch = useAuthFetch();
+  const [loading, setLoading] = useState(!user);
+
+  useEffect(() => {
+    if (user) {
+      setLoading(false);
+      return;
+    }
+
+    async function verifySession() {
+      try {
+        const response = await authFetch("/api/auth/verify", { method: "GET" });
+        if (!response.ok) {
+          setUser(null);
+          return;
+        }
+        const data = await response.json();
+        const user = UserSchema.parse(data.user);
+        setUser(user);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    verifySession();
+  }, [user, setUser]);
+
+  return { user, loading };
+}

--- a/client/src/screens/DashboardScreen.tsx
+++ b/client/src/screens/DashboardScreen.tsx
@@ -1,10 +1,19 @@
-import { Link } from "react-router";
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router";
 import Button from "../components/Button";
 import LogoutButton from "../components/LogoutButton";
 import SwampStudy from "../components/SwampStudy";
+import { useUserStore } from "../stores/userStore";
 
 export default function DashboardScreen() {
-  // Redirect to login screen when signed out
+  const navigate = useNavigate();
+  const user = useUserStore(state => state.user);
+  useEffect(() => {
+    if (!user) {
+      navigate("/login");
+    }
+  }, [user, navigate]);
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
       {/* Header Section */}
@@ -19,6 +28,10 @@ export default function DashboardScreen() {
       <div className="flex gap-4 mb-12">
         <Button to="/new-group" variant="primary">Create a Group</Button>
         <Button to="/find-group" variant="secondary">Join a Group</Button>
+      </div>
+
+      <div className="py-5">
+        <span className="font-bold">User:</span> {user ? user.name : "Not found"}
       </div>
 
       {/* My Groups Section */}

--- a/client/src/screens/DashboardScreen.tsx
+++ b/client/src/screens/DashboardScreen.tsx
@@ -1,18 +1,11 @@
-import { useEffect } from "react";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 import Button from "../components/Button";
 import LogoutButton from "../components/LogoutButton";
 import SwampStudy from "../components/SwampStudy";
-import { useUserStore } from "../stores/userStore";
+import { useAuth } from "../hooks/useAuth";
 
 export default function DashboardScreen() {
-  const navigate = useNavigate();
-  const user = useUserStore(state => state.user);
-  useEffect(() => {
-    if (!user) {
-      navigate("/login");
-    }
-  }, [user, navigate]);
+  const { user } = useAuth()
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -31,7 +24,8 @@ export default function DashboardScreen() {
       </div>
 
       <div className="py-5">
-        <span className="font-bold">User:</span> {user ? user.name : "Not found"}
+        <span className="font-bold">User:</span>{" "}
+        {user ? user.name : "Loading..."}
       </div>
 
       {/* My Groups Section */}

--- a/client/src/screens/GroupSearchScreen.tsx
+++ b/client/src/screens/GroupSearchScreen.tsx
@@ -5,7 +5,7 @@ import FormInput from "../components/FormInput";
 import NavBar from "../components/NavBar";
 import SwampStudy from "../components/SwampStudy";
 import { useFetchGroups } from "../hooks/useFetchGroups";
-import { Course, Group } from "../types";
+import { Course, GroupWithMemberCount } from "../types";
 import { useFetchCourses } from "../hooks/useFetchCourses";
 import { ChatBubbleLeftIcon, ChevronDownIcon, ChevronUpIcon, ClockIcon, MapPinIcon, UserGroupIcon, UserPlusIcon } from "@heroicons/react/16/solid";
 
@@ -81,7 +81,10 @@ export default function GroupSearchScreen() {
   );
 }
 
-function CourseTab({ course, groups }: { course: Course; groups: Group[] }) {
+function CourseTab({ course, groups }: {
+  course: Course;
+  groups: GroupWithMemberCount[];
+}) {
   const [isExpanded, setIsExpanded] = useState(true);
 
   return (
@@ -134,8 +137,7 @@ function formatDay(day: string) {
   return day.charAt(0).toUpperCase() + day.slice(1);
 };
 
-function GroupCard({ group }: { group: Group }) {
-
+function GroupCard({ group }: { group: GroupWithMemberCount }) {
   return (
     <div
       className="p-6 border border-gray-200 dark:border-gray-700
@@ -186,7 +188,13 @@ function GroupCard({ group }: { group: Group }) {
                         text-gray-500 dark:text-gray-400">
           <UserGroupIcon className="w-4 h-4 mr-1" />
           {/* TODO */}
-          <span>4 members</span>
+          {group.member_count === 0 && (
+            <span>No members</span>
+          ) || (
+            <span>
+              {group.member_count} member{group.member_count === 1 ? "" : "s"}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/screens/GroupSearchScreen.tsx
+++ b/client/src/screens/GroupSearchScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import Button from "../components/Button";
 import FormInput from "../components/FormInput";
@@ -7,24 +7,30 @@ import SwampStudy from "../components/SwampStudy";
 import { useFetchGroups } from "../hooks/useFetchGroups";
 import { Course, Group } from "../types";
 import { useFetchCourses } from "../hooks/useFetchCourses";
+import { ChatBubbleLeftIcon, ChevronDownIcon, ChevronUpIcon, ClockIcon, MapPinIcon, UserGroupIcon, UserPlusIcon } from "@heroicons/react/16/solid";
 
 export default function GroupSearchScreen() {
   const [searchQuery, setSearchQuery] = useState("");
   const { courses } = useFetchCourses();
   const { groups } = useFetchGroups();
 
-  // Filter groups based on search query
-  let filteredGroups: Group[] = [];
-  if (groups && courses) {
-    filteredGroups = groups.filter(group => {
-      const course = courses.find(course => course.id === group.course_id);
-      if (!course) return false;
-      return (
+  // Filter and organize groups by courses based on search query
+  const filteredAndGroupedData = useMemo(() => {
+    if (!courses || !groups) return [];
+
+    // First filter courses based on search
+    const filteredCourses = courses.filter(
+      (course) =>
         course.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         course.code.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-    });
-  }
+    );
+
+    // Then create course-group pairs
+    return filteredCourses.map((course) => ({
+      course,
+      groups: groups.filter((group) => group.course_id === course.id),
+    }));
+  }, [courses, groups, searchQuery]);
 
   return (
     <>
@@ -33,7 +39,7 @@ export default function GroupSearchScreen() {
         <h1 className="text-3xl font-bold text-center mb-8">
           <SwampStudy /> Join Room
         </h1>
-        
+
         <div className="mb-8">
           <FormInput
             type="text"
@@ -45,16 +51,16 @@ export default function GroupSearchScreen() {
           />
         </div>
 
-        {groups && courses && (
-          filteredGroups.length > 0 ? (
-            <div className="space-y-4">
-              {filteredGroups.map(group => (
-                <GroupCard group={group} courses={courses}/>
+        {groups && courses ? (
+          filteredAndGroupedData.length > 0 ? (
+            <div className="space-y-6">
+              {filteredAndGroupedData.map(({ course, groups }) => (
+                <CourseTab key={course.id} course={course} groups={groups} />
               ))}
             </div>
           ) : (
             <div className="text-center text-gray-600 dark:text-gray-400">
-              <p>No groups found matching your search.</p>
+              <p>No courses or groups found matching your search.</p>
               <p className="mt-4">
                 Can't find a group?{" "}
                 <Link
@@ -62,11 +68,12 @@ export default function GroupSearchScreen() {
                   className="text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   Create a new one
-                </Link>.
+                </Link>
+                .
               </p>
             </div>
           )
-        ) || (
+        ) : (
           <div>Loading...</div>
         )}
       </div>
@@ -74,48 +81,113 @@ export default function GroupSearchScreen() {
   );
 }
 
-function GroupCard({ group, courses }: { group: Group, courses: Course[] }) {
-  const course = courses.find(course => course.id === group.course_id);
-  if (!course) {
-    throw new Error("Group should always have associated course");
-  }
+function CourseTab({ course, groups }: { course: Course; groups: Group[] }) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700
+                    rounded-lg overflow-hidden">
+      <button
+        className="w-full p-4 flex justify-between items-center bg-gray-50
+                   dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <div>
+          <h2 className="text-xl font-semibold">{course.name}</h2>
+          <p className="text-gray-600 dark:text-gray-400">
+            {course.code} • {course.professor}
+          </p>
+        </div>
+        {isExpanded ? (
+          <ChevronUpIcon className="w-6 h-6" />
+        ) : (
+          <ChevronDownIcon className="w-6 h-6" />
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className="p-4 space-y-4">
+          {groups.length > 0 ? (
+            groups.map((group) => <GroupCard key={group.id} group={group} />)
+          ) : (
+            <p className="text-gray-600 dark:text-gray-400 text-center">
+              No study groups available for this course.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Format time with proper padding
+function formatTime(time: Date) {
+  const hours = time.getHours();
+  const minutes = time.getMinutes();
+  const period = hours >= 12 ? "PM" : "AM";
+  const formattedHours = hours % 12 || 12; // 24h -> 12h format
+  return `${formattedHours}:${minutes.toString().padStart(2, "0")} ${period}`;
+};
+
+// Format day to be capitalized
+function formatDay(day: string) {
+  return day.charAt(0).toUpperCase() + day.slice(1);
+};
+
+function GroupCard({ group }: { group: Group }) {
 
   return (
     <div
-      key={group.id}
-      className="p-4 border border-gray-200 dark:border-gray-700
+      className="p-6 border border-gray-200 dark:border-gray-700
                  rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800
-                 transition-colors"
+                 transition-colors shadow-sm"
     >
-      <h3 className="text-xl font-semibold">
-        {course.name}
-      </h3>
-      <div className="mt-2 space-y-1">
-        <p className="text-gray-600 dark:text-gray-400">
-          <span className="font-medium">Code:</span>{" "}
-          {course.code}
-        </p>
-        <p className="text-gray-600 dark:text-gray-400">
-          <span className="font-medium">Professor:</span>{" "}
-          {course.professor}
-        </p>
-        {group.meeting_location && (
-          <p className="text-gray-600 dark:text-gray-400">
-            <span className="font-medium">Location:</span>{" "}
-            {group.meeting_location}
-          </p>
-        )}
-        {group.meeting_day && group.meeting_time && (
-          <p className="text-gray-600 dark:text-gray-400">
-            <span className="font-medium">Time:</span>{" "}
-            {group.meeting_time.getHours()}:{group.meeting_time.getMinutes()}
-          </p>
-        )}
-      </div>
-      <div className="mt-4">
-        <Button variant="primary">
+      <div className="flex justify-between items-start">
+        <div>
+          <h3 className="text-lg font-semibold mb-2">{group.name}</h3>
+          <div className="space-y-2">
+            {group.meeting_day && group.meeting_time && (
+              <div className="flex items-center
+                              text-gray-600 dark:text-gray-400">
+                <ClockIcon className="w-5 h-5 mr-2" />
+                <span>
+                  {formatDay(group.meeting_day)}s at{" "}
+                  {formatTime(group.meeting_time)}
+                </span>
+              </div>
+            )}
+            {group.meeting_location && (
+              <div className="flex items-center
+                              text-gray-600 dark:text-gray-400">
+                <MapPinIcon className="w-5 h-5 mr-2" />
+                <span>{group.meeting_location}</span>
+              </div>
+            )}
+            <div className="flex items-center
+                            text-gray-600 dark:text-gray-400">
+              <ChatBubbleLeftIcon className="w-5 h-5 mr-2" />
+              <span>{group.contact_details}</span>
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          className="flex items-center gap-2"
+        >
+          <UserPlusIcon className="w-5 h-5" />
           Join Group
         </Button>
+      </div>
+
+      {/* Optional: Add member count or other metadata */}
+      <div className="mt-4 pt-4 border-t border-gray-200
+                      dark:border-gray-700">
+        <div className="flex items-center text-sm
+                        text-gray-500 dark:text-gray-400">
+          <UserGroupIcon className="w-4 h-4 mr-1" />
+          {/* TODO */}
+          <span>4 members</span>
+        </div>
       </div>
     </div>
   );

--- a/client/src/screens/GroupSearchScreen.tsx
+++ b/client/src/screens/GroupSearchScreen.tsx
@@ -102,7 +102,7 @@ export default function GroupSearchScreen() {
       <NavBar />
       <div className="max-w-4xl mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold text-center mb-8">
-          <SwampStudy /> Join Room
+          <SwampStudy /> Join Group
         </h1>
 
         <div className="mb-8">

--- a/client/src/screens/GroupSearchScreen.tsx
+++ b/client/src/screens/GroupSearchScreen.tsx
@@ -19,12 +19,12 @@ import { useFetchGroups } from "../hooks/useFetchGroups";
 import {
   Course,
   GroupWithMemberCount,
-  User,
   UserGroup,
   UserGroupSchema,
 } from "../types";
 import { useFetchCourses } from "../hooks/useFetchCourses";
 import { useAuthFetch } from "../hooks/useAuthFetch";
+import { useAuth } from "../hooks/useAuth";
 import { useUserStore } from "../stores/userStore";
 
 export async function attemptJoinGroup(
@@ -74,6 +74,7 @@ export async function attemptJoinGroup(
 }
 
 export default function GroupSearchScreen() {
+  useAuth();
   const [searchQuery, setSearchQuery] = useState("");
   const { courses } = useFetchCourses();
   const { groups } = useFetchGroups();

--- a/client/src/screens/GroupSearchScreen.tsx
+++ b/client/src/screens/GroupSearchScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "../types";
 import { useFetchCourses } from "../hooks/useFetchCourses";
 import { useAuthFetch } from "../hooks/useAuthFetch";
+import { useUserStore } from "../stores/userStore";
 
 export async function attemptJoinGroup(
   groupId: number,
@@ -205,8 +206,7 @@ function GroupCard({ group }: { group: GroupWithMemberCount }) {
   const [error, setError] = useState<string | null>(null);
   const authFetch = useAuthFetch();
   const navigate = useNavigate();
-  // const { user } = useUserStore();
-  const user: User | null = null;
+  const user = useUserStore(state => state.user);
 
   async function handleJoinGroup() {
     if (!user) {

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -1,7 +1,10 @@
 import Button from "../components/Button";
 import SwampStudy from "../components/SwampStudy";
+import { useOptionalUser } from "../hooks/useOptionalUser";
 
 export default function HomeScreen() {
+  const { user } = useOptionalUser();
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="max-w-2xl mx-auto text-center space-y-8">
@@ -16,9 +19,13 @@ export default function HomeScreen() {
           </p>
         </div>
 
-        {/* Login and Signup Buttons */}
+        {/* Navigation Buttons */}
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Button to="/login" variant="primary">Login</Button>
+          {user && (
+            <Button to="/dashboard" variant="primary">Dashboard</Button>
+          ) || (
+            <Button to="/login" variant="primary">Login</Button>
+          )}
           <Button to="/register" variant="secondary">Sign Up</Button>
         </div>
 

--- a/client/src/screens/NewClassScreen.tsx
+++ b/client/src/screens/NewClassScreen.tsx
@@ -6,6 +6,7 @@ import FormInput from "../components/FormInput";
 import NavBar from "../components/NavBar";
 import SwampStudy from "../components/SwampStudy";
 import { useAuthFetch } from "../hooks/useAuthFetch";
+import { useAuth } from "../hooks/useAuth";
 
 type ClassData = {
   name: string;
@@ -54,6 +55,7 @@ async function attemptAddClass(
 }
 
 export default function NewClassScreen() {
+  useAuth();
   const authFetch = useAuthFetch();
   const navigate = useNavigate();
   const [formData, setFormData] = useState<ClassData>({

--- a/client/src/screens/NewGroupScreen.tsx
+++ b/client/src/screens/NewGroupScreen.tsx
@@ -76,6 +76,7 @@ export async function attemptCreateGroup(
 export default function NewGroupScreen() {
   const authFetch = useAuthFetch();
   const navigate = useNavigate();
+  const { courses } = useFetchCourses();
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [formData, setFormData] = useState<GroupFormData>({
@@ -89,15 +90,12 @@ export default function NewGroupScreen() {
     contactDetails: "",
   });
 
-  const { courses } = useFetchCourses();
-
   let matches: Course[] = [];
   if (formData.classCode && courses) {
     matches = courses.filter(course =>
       course.code.toLowerCase().startsWith(formData.classCode.toLowerCase())
     );
   }
-
 
   function handleInputChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement

--- a/client/src/screens/NewGroupScreen.tsx
+++ b/client/src/screens/NewGroupScreen.tsx
@@ -9,6 +9,7 @@ import TermDropdown, { courseTermData } from "../components/TermDropdown";
 import { useAuthFetch } from "../hooks/useAuthFetch";
 import { Course, NewGroupInput, NewGroupInputSchema, Weekday } from "../types";
 import { useFetchCourses } from "../hooks/useFetchCourses";
+import { useAuth } from "../hooks/useAuth";
 
 const daysOfWeek: {
   value: Weekday;
@@ -74,6 +75,7 @@ export async function attemptCreateGroup(
 }
 
 export default function NewGroupScreen() {
+  useAuth();
   const authFetch = useAuthFetch();
   const navigate = useNavigate();
   const { courses } = useFetchCourses();

--- a/client/src/screens/RegisterScreen.tsx
+++ b/client/src/screens/RegisterScreen.tsx
@@ -6,6 +6,7 @@ import Button from "../components/Button";
 import FormInput from "../components/FormInput";
 import SwampStudy from "../components/SwampStudy";
 import Modal from "../components/Modal";
+import { useUserStore } from "../stores/userStore";
 
 
 function formatTimeRemaining(seconds: number): string {
@@ -17,6 +18,7 @@ function formatTimeRemaining(seconds: number): string {
 
 export default function RegisterScreen() {
   const navigate = useNavigate();
+  const setUser = useUserStore(state => state.setUser);
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
@@ -134,7 +136,7 @@ export default function RegisterScreen() {
         email: formData.email.trim().toLowerCase(),
         password: formData.password.trim(),
       };
-      attemptLogin(credentials, navigate, setError, setIsLoading);
+      attemptLogin(credentials, navigate, setError, setIsLoading, setUser);
     } catch (err) {
       console.warn("Error registering user:", err);
       setVerificationError(

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { User } from "../types";
+
+type UserStore = {
+  user: User | null;
+  setUser: (user: User | null) => void;
+};
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+}));

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -13,9 +13,7 @@ export const TimeSchema = z.preprocess((val) => {
     const match = val.match(timeOnly);
     if (match) {
       const [, h, m, s = "00"] = match;
-      const date = new Date(
-        Date.UTC(1970, 0, 1, Number(h), Number(m), Number(s))
-      );
+      const date = new Date(1970, 0, 1, Number(h), Number(m), Number(s));
       return isNaN(date.getTime()) ? undefined : date;
     }
     // Try to parse as ISO string

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -97,6 +97,10 @@ export const GroupSchema = z.object({
   created_at: DateSchema,
 });
 
+export const GroupWithMemberCountSchema = GroupSchema.and(z.object({
+  member_count: z.number().int().nonnegative(),
+}));
+
 export const NewGroupInputSchema = GroupSchema.omit({
   id: true,
   created_at: true,
@@ -113,6 +117,7 @@ export type User = z.infer<typeof UserSchema>;
 export type UserSession = z.infer<typeof UserSessionSchema>;
 export type Course = z.infer<typeof CourseSchema>;
 export type Group = z.infer<typeof GroupSchema>;
+export type GroupWithMemberCount = z.infer<typeof GroupWithMemberCountSchema>;
 export type UserGroup = z.infer<typeof UserGroupSchema>;
 
 export type NewUserInput = z.infer<typeof NewUserInputSchema>;

--- a/server/src/db/reset_schema.sql
+++ b/server/src/db/reset_schema.sql
@@ -1,0 +1,19 @@
+-- 1. Drop indexes
+DROP INDEX IF EXISTS idx_pending_verifications_expires_at;
+
+-- 2. Drop tables (most dependent first)
+DROP TABLE IF EXISTS user_groups CASCADE;
+DROP TABLE IF EXISTS user_sessions CASCADE;
+DROP TABLE IF EXISTS user_events CASCADE;
+DROP TABLE IF EXISTS group_events CASCADE;
+DROP TABLE IF EXISTS groups CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS courses CASCADE;
+DROP TABLE IF EXISTS pending_verifications CASCADE;
+
+-- 3. Drop types (most dependent first)
+DROP TYPE IF EXISTS user_group_role CASCADE;
+DROP TYPE IF EXISTS group_notification_scope CASCADE;
+DROP TYPE IF EXISTS course_term CASCADE;
+DROP TYPE IF EXISTS weekday CASCADE;
+DROP TYPE IF EXISTS user_role CASCADE;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -16,6 +16,7 @@ import {
   getSessionByAccessToken,
   getSessionByRefreshToken,
   getUserByEmail,
+  getUserById,
   HashedUserInput,
   updateSessionTokens,
   upsertPendingVerification,
@@ -128,7 +129,7 @@ const authRoutes: FastifyPluginAsync = async (server) => {
     session.session = newSession;
     setTokenCookies(reply, tokenData);
     console.log("Refresh successful");
-    return { status: "success", data: session };
+    return { status: "success", user: session.user };
   });
 
   // GET /auth/verify - Verifies access token.
@@ -181,7 +182,7 @@ const authRoutes: FastifyPluginAsync = async (server) => {
       setTokenCookies(reply, tokenData);
 
       console.log(`Login successful: ${email}`);
-      return { message: "Login successful" };
+      return { message: "Login successful", user };
     } catch (error) {
       reply.code(500);
       console.log(error);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -16,7 +16,6 @@ import {
   getSessionByAccessToken,
   getSessionByRefreshToken,
   getUserByEmail,
-  getUserById,
   HashedUserInput,
   updateSessionTokens,
   upsertPendingVerification,

--- a/server/src/routes/group.ts
+++ b/server/src/routes/group.ts
@@ -224,10 +224,10 @@ const groupRoutes: FastifyPluginAsync = async (server) => {
       const currentRole = await getUserGroupRole(
         server, user_id, group_id
       );
-      if (currentRole && currentRole.group_role === role) {
+      if (currentRole) {
         reply.code(409);
-        console.log(`User ${user_id} already in group ${group_id}`);
-        return { error: "User already in group." };
+        console.log(`User ${user_id} is already in group ${group_id}`);
+        return { error: "You are already in this group." };
       }
       const userGroup = await addUserToGroup(server, user_id, group_id, role);
       reply.code(201);

--- a/server/src/routes/group.ts
+++ b/server/src/routes/group.ts
@@ -6,6 +6,7 @@ import {
   createGroupWithOwner,
   deleteGroup,
   getAllGroups,
+  getAllGroupsWithMemberCounts,
   getGroupById,
   getUserGroupRole,
   getUsersInGroup,
@@ -45,7 +46,7 @@ function getGroupAndUserIdParams(
 }
 
 const groupRoutes: FastifyPluginAsync = async (server) => {
-  // GET /group/ - Get all groups.
+  // GET /group/ - Get all groups with member counts.
   server.get("/", async (request, reply) => {
     const session = await verifyAccessToken(request, reply);
     if (!session) {
@@ -54,7 +55,7 @@ const groupRoutes: FastifyPluginAsync = async (server) => {
     }
 
     try {
-      const groups = await getAllGroups(server);
+      const groups = await getAllGroupsWithMemberCounts(server);
       return groups;
     } catch (error) {
       reply.code(500);

--- a/server/src/routes/group.ts
+++ b/server/src/routes/group.ts
@@ -5,7 +5,6 @@ import {
   addUserToGroup,
   createGroupWithOwner,
   deleteGroup,
-  getAllGroups,
   getAllGroupsWithMemberCounts,
   getGroupById,
   getUserGroupRole,
@@ -222,6 +221,14 @@ const groupRoutes: FastifyPluginAsync = async (server) => {
     }
 
     try {
+      const currentRole = await getUserGroupRole(
+        server, user_id, group_id
+      );
+      if (currentRole && currentRole.group_role === role) {
+        reply.code(409);
+        console.log(`User ${user_id} already in group ${group_id}`);
+        return { error: "User already in group." };
+      }
       const userGroup = await addUserToGroup(server, user_id, group_id, role);
       reply.code(201);
       return userGroup;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -13,9 +13,7 @@ export const TimeSchema = z.preprocess((val) => {
     const match = val.match(timeOnly);
     if (match) {
       const [, h, m, s = "00"] = match;
-      const date = new Date(
-        Date.UTC(1970, 0, 1, Number(h), Number(m), Number(s))
-      );
+      const date = new Date(1970, 0, 1, Number(h), Number(m), Number(s));
       return isNaN(date.getTime()) ? undefined : date;
     }
     // Try to parse as ISO string

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -97,6 +97,10 @@ export const GroupSchema = z.object({
   created_at: DateSchema,
 });
 
+export const GroupWithMemberCountSchema = GroupSchema.and(z.object({
+  member_count: z.number().int().nonnegative(),
+}));
+
 export const NewGroupInputSchema = GroupSchema.omit({
   id: true,
   created_at: true,
@@ -113,6 +117,7 @@ export type User = z.infer<typeof UserSchema>;
 export type UserSession = z.infer<typeof UserSessionSchema>;
 export type Course = z.infer<typeof CourseSchema>;
 export type Group = z.infer<typeof GroupSchema>;
+export type GroupWithMemberCount = z.infer<typeof GroupWithMemberCountSchema>;
 export type UserGroup = z.infer<typeof UserGroupSchema>;
 
 export type NewUserInput = z.infer<typeof NewUserInputSchema>;

--- a/server/tests/auth.integration.test.ts
+++ b/server/tests/auth.integration.test.ts
@@ -189,7 +189,7 @@ describe("Authentication Integration", () => {
     expect(refreshResponse.statusCode).toBe(200);
     const refreshBody = JSON.parse(refreshResponse.payload);
     expect(refreshBody.status).toBe("success");
-    expect(refreshBody.data).toBeDefined();
+    expect(refreshBody.user).toBeDefined();
 
     let newCookies = refreshResponse.headers["set-cookie"];
     expect(newCookies).toBeDefined();


### PR DESCRIPTION
This PR includes creating a fully functioning group search page that allows users to join groups. This entailed setting up state and authentication state management to make the group join requests (because they require the user id). State management was done with Zustand, and user information was obtained from the `/api/auth/verify` and `/api/auth/login` endpoints and validated with Zod. Authentication state management is handled on the page level through the use of the `useAuth()` and `useOptionalUser()` hooks to facilitate the fetching of user state and redirecting unauthenticated users to `/login` in the case of `useAuth()`.

The only features left for the primary user flow of creating and joining groups is the displaying of a user's groups on the dashboard and possibly email notifications.